### PR TITLE
Fix lintDirtyModulesOnly option for some cases

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,7 @@ export function parseFiles(files, context) {
       `${replaceBackslashes(context).replace(
         UNESCAPED_GLOB_SYMBOLS_RE,
         '\\$2'
-      )}/${replaceBackslashes(file)}`
+      )}/${replaceBackslashes(file === '.' ? '' : file)}`
   );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,10 @@ export function parseFoldersToGlobs(patterns, extensions) {
         // The patterns are absolute because they are prepended with the context.
         const stats = statSync(pattern);
         if (stats.isDirectory()) {
-          return pattern.replace(/[/\\]?$/u, `/**/*.{${extensionsGlob}}`);
+          // only brace if there are more than 1 extensions
+          return extensions.length > 1
+            ? pattern.replace(/[/\\]?$/u, `/**/*.{${extensionsGlob}}`)
+            : pattern.replace(/[/\\]?$/u, `/**/*.${extensionsGlob}`);
         }
       } catch (_) {
         // Return the pattern as is on error.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** (see below)
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When enabling `lintDirtyModulesOnly` in my Webpack config, `eslint-webpack-plugin` didn't flag my dirty files. I traced it down to 2 things:

1. Braces [does not expand single items](https://github.com/micromatch/braces#escaping), like `a{b}c` or `somefile.{js}`. This triggers often since the default value for the `extensions` option is `'js'`.
1. `micromatch.isMatch` did not appear to match on paths with `/./` in them, which is the case with the default value for the `files` option. I don't think my solution is the most elegant :/

I tried writing new tests for these cases, but was actually unable to create breaking cases as a baseline. For instance, I tried changing line 18 in `dirty-file-watcher.test.js` to `const watcher = new DirtyFileWatcher('.', 'js')` and it still didn't fail.  
If you can point me in the right direction on how to write tests for these, I'll give it another go!

### Breaking Changes

None

### Additional Info

None