### PR TITLE
Fix folder pattern

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ export function parseFoldersToGlobs(patterns, extensions) {
         /* istanbul ignore else */
         if (stats.isDirectory()) {
           return pattern.replace(
-            /[/\\]+?$/u,
+            /[/\\]*?$/u,
             `/**/*.${prefix + extensionsGlob + postfix}`
           );
         }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,50 @@
+import { parseFoldersToGlobs } from '../src/utils';
+
+jest.mock('fs', () => {
+  return {
+    statSync(pattern) {
+      return {
+        isDirectory() {
+          return pattern.indexOf('/path/') === 0;
+        },
+      };
+    },
+  };
+});
+
+test('parseFoldersToGlobs should return globs for folders', () => {
+  const withoutSlash = '/path/to/code';
+  const withSlash = `${withoutSlash}/`;
+
+  expect(parseFoldersToGlobs(withoutSlash, 'js')).toMatchInlineSnapshot(`
+    Array [
+      "/path/to/code/**/*.js",
+    ]
+  `);
+  expect(parseFoldersToGlobs(withSlash, 'js')).toMatchInlineSnapshot(`
+    Array [
+      "/path/to/code/**/*.js",
+    ]
+  `);
+
+  expect(
+    parseFoldersToGlobs(
+      [withoutSlash, withSlash, '/some/file.js'],
+      ['js', 'cjs', 'mjs']
+    )
+  ).toMatchInlineSnapshot(`
+    Array [
+      "/path/to/code/**/*.{js,cjs,mjs}",
+      "/path/to/code/**/*.{js,cjs,mjs}",
+      "/some/file.js",
+    ]
+  `);
+});
+
+test('parseFoldersToGlobs should return unmodified globs for globs (ignoring extensions)', () => {
+  expect(parseFoldersToGlobs('**.notjs', 'js')).toMatchInlineSnapshot(`
+    Array [
+      "**.notjs",
+    ]
+  `);
+});


### PR DESCRIPTION
Paths computed from node's path modules often do not end in with a slash, this replacement fails if there is no slash... which it was not meant to. (we already know the path points to a directory...

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Keep defaults sane.

### Additional Info


