### PR TITLE
fix: strip resource query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "^7.2.4",
@@ -8481,13 +8481,10 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -22331,9 +22328,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "interpret": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { isAbsolute, join } from 'path';
-import { parse } from 'url';
 
 import arrify from 'arrify';
 import micromatch from 'micromatch';
@@ -81,7 +80,7 @@ export class ESLintWebpackPlugin {
 
       // @ts-ignore
       const processModule = (module) => {
-        const file = parse(module.resource).pathname;
+        const file = module.resource.split('?')[0];
 
         if (
           file &&

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { isAbsolute, join } from 'path';
+import { parse } from 'url';
 
 import arrify from 'arrify';
 import micromatch from 'micromatch';
@@ -80,7 +81,7 @@ export class ESLintWebpackPlugin {
 
       // @ts-ignore
       const processModule = (module) => {
-        const file = module.resource;
+        const file = parse(module.resource).pathname;
 
         if (
           file &&

--- a/test/fixtures/query-entry.js
+++ b/test/fixtures/query-entry.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
+require('./good.js?some-query=1234.js');

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,0 +1,15 @@
+import pack from './utils/pack';
+
+describe('query', () => {
+  it('should correctly resolve file despite query path', (done) => {
+    const compiler = pack('query');
+
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(false);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Prior to this PR, eslint-webpack-plugin was not stripping Webpack path queries in resource paths and was failing to resolve files with resource queries in its path (eg. "virtual files" created by Webpack loaders). This is a regression introduced in [v2.2.0](https://github.com/webpack-contrib/eslint-webpack-plugin/releases/tag/v2.2.0).

For example, [mdvue-loader](https://github.com/privatenumber/md-vue-loader) loads Markdown files as Vue components and also renders Vue code-blocks in the markdown file. To accomplish this, it imports the specific code-block as a virtual module via a query path like this:

```
/project/README.md?vue&type=script&lang=js&mdvue-file=Demo.vue
```

Given a ESLintPlugin configuration like this, the `.vue` at the end of the query makes micromatch detect it as a file:

```js
new ESLintPlugin({
	files: '**/*.{vue,js,md}',
	emitWarning: true,
})
```


<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
- The fix strips resource queries using `url.parse`.
- `url.parse` is actually deprecated, but decided to still use it as `new URL` might not be available in older versions of Node.js (globalized in v10). `new URL` also doesn't support relative paths.
- It might be fine to just do `module.resource.split('?')[0]` as well but unsure how well that scales. Seems like macOS allows `?` in the filename, and that seems to break `url.parse` too.