### PR TITLE
fix: fails when `failOnError` or `failOnWarning` enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ Will always return warnings, if set to `true`.
 #### `failOnError`
 
 - Type: `Boolean`
-- Default: `false`
+- Default: `true`
 
-Will cause the module build to fail and not emitted files if there are any errors, if set to `true`.
+Will cause the module build to fail if there are any errors, to disable set to `false`.
 
 #### `failOnWarning`
 
 - Type: `Boolean`
 - Default: `false`
 
-Will cause the module build to fail and not emitted files if there are any warnings, if set to `true`.
+Will cause the module build to fail if there are any warnings, if set to `true`.
 
 #### `quiet`
 

--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ Will always return warnings, if set to `true`.
 - Type: `Boolean`
 - Default: `false`
 
-Will cause the module build to fail if there are any errors, if set to `true`.
+Will cause the module build to fail and not emitted files if there are any errors, if set to `true`.
 
 #### `failOnWarning`
 
 - Type: `Boolean`
 - Default: `false`
 
-Will cause the module build to fail if there are any warnings, if set to `true`.
+Will cause the module build to fail and not emitted files if there are any warnings, if set to `true`.
 
 #### `quiet`
 

--- a/src/ESLintError.js
+++ b/src/ESLintError.js
@@ -1,7 +1,4 @@
-// @ts-ignore
-import WebpackError from 'webpack/lib/WebpackError';
-
-export default class ESLintError extends WebpackError {
+class ESLintError extends Error {
   /**
    * @param {string=} messages
    */
@@ -11,3 +8,5 @@ export default class ESLintError extends WebpackError {
     this.stack = '';
   }
 }
+
+export default ESLintError;

--- a/src/index.js
+++ b/src/index.js
@@ -114,17 +114,23 @@ export class ESLintWebpackPlugin {
       compilation.hooks.succeedModule.tap(ESLINT_PLUGIN, processModule);
 
       // await and interpret results
-      compilation.compiler.hooks.emit.tapPromise(ESLINT_PLUGIN, processResults);
+      compilation.hooks.additionalAssets.tapPromise(
+        ESLINT_PLUGIN,
+        processResults
+      );
 
       async function processResults() {
         const { errors, warnings, generateReportAsset } = await report();
 
-        if (warnings) {
+        if (warnings && !options.failOnWarning) {
           // @ts-ignore
           compilation.warnings.push(warnings);
+        } else if (warnings && options.failOnWarning) {
+          // @ts-ignore
+          compilation.errors.push(warnings);
         }
 
-        if (errors) {
+        if (errors && options.failOnError) {
           // @ts-ignore
           compilation.errors.push(errors);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -112,8 +112,9 @@ export class ESLintWebpackPlugin {
 
       // Gather Files to lint
       compilation.hooks.succeedModule.tap(ESLINT_PLUGIN, processModule);
+
       // await and interpret results
-      compilation.hooks.afterSeal.tapPromise(ESLINT_PLUGIN, processResults);
+      compilation.compiler.hooks.emit.tapPromise(ESLINT_PLUGIN, processResults);
 
       async function processResults() {
         const { errors, warnings, generateReportAsset } = await report();

--- a/src/linter.js
+++ b/src/linter.js
@@ -94,12 +94,6 @@ export default function linter(key, options, compilation) {
       parseResults(options, results)
     );
 
-    if (options.failOnError && errors) {
-      throw errors;
-    } else if (options.failOnWarning && warnings) {
-      throw warnings;
-    }
-
     return {
       errors,
       warnings,

--- a/src/options.js
+++ b/src/options.js
@@ -47,6 +47,7 @@ import schema from './options.json';
 export function getOptions(pluginOptions) {
   const options = {
     extensions: 'js',
+    failOnError: true,
     ...pluginOptions,
     ...(pluginOptions.quiet ? { emitError: true, emitWarning: false } : {}),
   };

--- a/src/options.json
+++ b/src/options.json
@@ -23,7 +23,7 @@
       "anyOf": [{ "type": "string" }, { "type": "array" }]
     },
     "failOnError": {
-      "description": "Will cause the module build to fail if there are any errors, if set to `true`.",
+      "description": "Will cause the module build to fail if there are any errors, to disable set to `false`.",
       "type": "boolean"
     },
     "failOnWarning": {

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -4,8 +4,9 @@ describe('fail on error', () => {
   it('should emits errors', (done) => {
     const compiler = pack('error', { failOnError: true });
 
-    compiler.run((err) => {
-      expect(err.message).toContain('error.js');
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasErrors()).toBe(true);
       done();
     });
   });

--- a/test/fail-on-warning.test.js
+++ b/test/fail-on-warning.test.js
@@ -4,8 +4,9 @@ describe('fail on warning', () => {
   it('should emits errors', (done) => {
     const compiler = pack('warn', { failOnWarning: true });
 
-    compiler.run((err) => {
-      expect(err.message).toContain('warn.js');
+    compiler.run((err, stats) => {
+      expect(err).toBeNull();
+      expect(stats.hasErrors()).toBe(true);
       done();
     });
   });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Fix when `failOnError` or` failOnWarning` is enabled and there is an error or warning from eslint locking the compilation and not displaying anything.

Resolve #51, #21, #71


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
