### PR TITLE
fix: prevent lint all files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,27 +95,28 @@ class ESLintWebpackPlugin {
         return;
       }
 
-      // Gather Files to lint
-      compilation.hooks.finishModules.tap(ESLINT_PLUGIN, (modules) => {
-        /** @type {string[]} */
-        const files = [];
+      /** @type {string[]} */
+      const files = [];
 
-        // @ts-ignore
-        for (const { resource } of modules) {
-          if (resource) {
-            const [file] = resource.split('?');
+      // @ts-ignore
+      // Add the file to be linted
+      compilation.hooks.succeedModule.tap(ESLINT_PLUGIN, ({ resource }) => {
+        if (resource) {
+          const [file] = resource.split('?');
 
-            if (
-              file &&
-              !files.includes(file) &&
-              isMatch(file, wanted) &&
-              !isMatch(file, exclude)
-            ) {
-              files.push(file);
-            }
+          if (
+            file &&
+            !files.includes(file) &&
+            isMatch(file, wanted) &&
+            !isMatch(file, exclude)
+          ) {
+            files.push(file);
           }
         }
+      });
 
+      // Lint all files added
+      compilation.hooks.finishModules.tap(ESLINT_PLUGIN, () => {
         if (files.length > 0) {
           lint(files);
         }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The goal is to group the changed files and execute lint only at the end

`succeedModule` its called for every file and watch mode just file changed
`finishModules` is called with all modules and is responsible for linting added files

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Resolve #75 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
