### PR TITLE
fix: match hidden directories for path exclusions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class ESLintWebpackPlugin {
           if (
             file &&
             !files.includes(file) &&
-            isMatch(file, wanted) &&
+            isMatch(file, wanted, { dot: true }) &&
             !isMatch(file, exclude, { dot: true })
           ) {
             files.push(file);

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ class ESLintWebpackPlugin {
             file &&
             !files.includes(file) &&
             isMatch(file, wanted) &&
-            !isMatch(file, exclude)
+            !isMatch(file, exclude, { dot: true })
           ) {
             files.push(file);
           }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Globstars don't match paths with hidden directories by default: https://github.com/isaacs/minimatch/issues/51
This means the default `exclude` option of `**/node_modules/**` will fail for projects anchored at a path like /foo/.bar/. E.g. it is fairly common for developers to mimic FHS directory structures in their home directory using `.local`, meaning repositories are cloned within `~/.local/src/`, which would not be matched by the default globstar. In all likelihood most users would expect matching hidden directories to be the default behaviour.

