### PR TITLE
Fix paths for isMatch check

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,12 +76,14 @@ export function parseFoldersToGlobs(patterns, extensions = []) {
       const stats = statSync(pattern);
       /* istanbul ignore else */
       if (stats.isDirectory()) {
-        return pattern.replace(
+        const glob = pattern.replace(
           /[/\\]*?$/u,
           `/**${
             extensionsGlob ? `/*.${prefix + extensionsGlob + postfix}` : ''
           }`
         );
+        
+        return normalizePath(glob);
       }
     } catch (_) {
       // Return the pattern as is on error.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
When comparing whether the file is suitable for the requirements (wanted or exclude), then in some cases the check will return false. For example, like in this case: [Issue #93](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/93), which I also encountered just today.
