### PR TITLE
Escaping glob patterns from context. Issue #132

### DIFF
--- a/declarations/utils.d.ts
+++ b/declarations/utils.d.ts
@@ -39,4 +39,9 @@ export function parseFoldersToGlobs(
   patterns: string | string[],
   extensions?: string | string[]
 ): string[];
+/**
+ * @param {string} string
+ * @returns {string}
+ */
+export function escapeGlobBrackets(string: string): string;
 export function jsonStringifyReplacerSortKeys(_: string, value: any): any;

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,6 @@ import { isMatch } from 'micromatch';
 import { getOptions } from './options';
 import linter from './linter';
 import { arrify, parseFiles, parseFoldersToGlobs, escapeGlobBrackets } from './utils';
-// @ts-ignore
-import normalizePath from 'normalize-path';
 
 /** @typedef {import('webpack').Compiler} Compiler */
 /** @typedef {import('./options').Options} Options */
@@ -106,7 +104,7 @@ class ESLintWebpackPlugin {
       // Add the file to be linted
       compilation.hooks.succeedModule.tap(this.key, ({ resource }) => {
         if (resource) {
-          const file = resource.split('?')[0];
+          const [file] = resource.split('?');
 
           if (
             file &&

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,9 @@ import { isMatch } from 'micromatch';
 
 import { getOptions } from './options';
 import linter from './linter';
-import { arrify, parseFiles, parseFoldersToGlobs } from './utils';
+import { arrify, parseFiles, parseFoldersToGlobs, escapeGlobBrackets } from './utils';
+// @ts-ignore
+import normalizePath from 'normalize-path';
 
 /** @typedef {import('webpack').Compiler} Compiler */
 /** @typedef {import('./options').Options} Options */
@@ -104,7 +106,7 @@ class ESLintWebpackPlugin {
       // Add the file to be linted
       compilation.hooks.succeedModule.tap(this.key, ({ resource }) => {
         if (resource) {
-          const [file] = resource.split('?');
+          const file = resource.split('?')[0];
 
           if (
             file &&
@@ -164,14 +166,14 @@ class ESLintWebpackPlugin {
    */
   getContext(compiler) {
     if (!this.options.context) {
-      return String(compiler.options.context);
+      return escapeGlobBrackets(String(compiler.options.context));
     }
 
     if (!isAbsolute(this.options.context)) {
-      return join(String(compiler.options.context), this.options.context);
+      return escapeGlobBrackets(join(String(compiler.options.context), this.options.context));
     }
 
-    return this.options.context;
+    return escapeGlobBrackets(this.options.context);
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,3 +109,13 @@ export const jsonStringifyReplacerSortKeys = (_, value) => {
     ? Object.keys(value).sort().reduce(insert, {})
     : value;
 };
+
+/**
+ * @param {string} string
+ * @returns {string}
+ */
+export function escapeGlobBrackets(string) {
+  return string
+    .replace(/(?<!\[)\[(?!\[|\])/g, '[[]')
+    .replace(/(?<!\]|\[)\](?!\])/g, '[]]');
+}

--- a/test/symbols.test.js
+++ b/test/symbols.test.js
@@ -10,7 +10,10 @@ describe('symbols', () => {
   it('should return error', (done) => {
     const compiler = pack(
       'symbols',
-      { context: join(__dirname, 'fixtures/[symbols]') },
+      { 
+        context: join(__dirname, 'fixtures/[symbols]'),
+        files: './**/*'
+      },
       {}
     );
 

--- a/test/symbols.test.js
+++ b/test/symbols.test.js
@@ -10,8 +10,8 @@ describe('symbols', () => {
   it('should return error', (done) => {
     const compiler = pack(
       'symbols',
-      {},
-      { context: join(__dirname, 'fixtures/[symbols]') }
+      { context: join(__dirname, 'fixtures/[symbols]') },
+      {}
     );
 
     compiler.run((err, stats) => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
If you do not escape glob patterns from context, then the plugin will not match files for linting.

I described the problem in detail in [Issue #132](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/132)

### Additional Info
Also, this is not the only problem that square brackets are causing. At least that's what the tests say.
If, again, there are brackets in the name of one of the directories before the project, then most of the tests will fail.
