### PR TITLE
Make typescript entrypoint reflect actual runtime cjs entrypoint shape

### DIFF
--- a/declarations/index.d.ts
+++ b/declarations/index.d.ts
@@ -1,6 +1,8 @@
-export default ESLintWebpackPlugin;
-export type Compiler = import('webpack').Compiler;
-export type Options = import('./options').Options;
+export = ESLintWebpackPlugin;
+declare namespace ESLintWebpackPlugin {
+  export type Compiler = import('webpack').Compiler;
+  export type Options = import('./options').Options;
+}
 declare class ESLintWebpackPlugin {
   /**
    * @param {Options} options


### PR DESCRIPTION
Per [this issue](https://github.com/microsoft/TypeScript/issues/47332) over on the TS repo, the current shape described by the types does not accurately describe the runtime shape of the entrypoint.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
