### PR TITLE
fix: use `stillValidModule` only `lintDirtyModulesOnly` is disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,10 @@ class ESLintWebpackPlugin {
 
       // Add the file to be linted
       compilation.hooks.succeedModule.tap(this.key, addFile);
-      compilation.hooks.stillValidModule.tap(this.key, addFile);
+
+      if (!this.options.lintDirtyModulesOnly) {
+        compilation.hooks.stillValidModule.tap(this.key, addFile);
+      }
 
       /**
        * @param {Module} module


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Resolve #215 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
No

### Additional Info

No