### PR TITLE
fix: don't error on circular eslint plugins

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -89,29 +89,8 @@ function parseFoldersToGlobs(patterns, extensions = []) {
   });
 }
 
-/**
- * @param {string} _ key, but unused
- * @param {any} value
- */
-const jsonStringifyReplacerSortKeys = (_, value) => {
-  /**
-   * @param {{ [x: string]: any; }} sorted
-   * @param {string | number} key
-   */
-  const insert = (sorted, key) => {
-    // eslint-disable-next-line no-param-reassign
-    sorted[key] = value[key];
-    return sorted;
-  };
-
-  return value instanceof Object && !(value instanceof Array)
-    ? Object.keys(value).sort().reduce(insert, {})
-    : value;
-};
-
 module.exports = {
   arrify,
   parseFiles,
   parseFoldersToGlobs,
-  jsonStringifyReplacerSortKeys,
 };

--- a/test/circular-plugin.test.js
+++ b/test/circular-plugin.test.js
@@ -1,0 +1,34 @@
+import pack from './utils/pack';
+
+describe('circular plugin', () => {
+  it('should support plugins with circular configs', async () => {
+    const plugin = {
+      configs: {},
+      rules: {},
+      processors: {},
+    };
+
+    Object.assign(plugin.configs, {
+      recommended: {
+        plugins: {
+          self: plugin,
+        },
+        rules: {},
+      },
+    });
+
+    const loaderOptions = {
+      configType: 'flat',
+      overrideConfig: {
+        plugins: { plugin: plugin },
+      },
+      overrideConfigFile: true,
+    };
+
+    const compiler = pack('good', loaderOptions);
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Previously, attempting to use an overridden config containing a plugin with a circular structure (as is suggested for flat configs) would error, as the caching implementation would attempt to `stringify` said plugins in order to use them as cache keys.

This PR fixes the issue by replacing the cache object with a `Map`, and using the plugin objects directly as keys, for whom equality can be checked even in the presence of circular references.

A test case (verified to error without the fix) is also included.

Fixes: #270.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None (unless `jsonStringifyReplacerSortKeys` was somehow externally visible in a way I didn't notice).

### Additional Info

Test case plugin code is taken almost exactly from https://eslint.org/docs/latest/extend/plugin-migration-flat-config#migrating-configs-for-flat-config; it is probably possible to make it a bit shorter, but I didn't bother to look into it.

`npm run test` was run immediately prior to the final (and only) commit, so any stylistic lints should have been applied, but apologies if I've missed anything.