### PR TITLE
fix: don't error on circular eslint plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "^9.6.1",
+        "flatted": "^3.3.3",
         "jest-worker": "^29.7.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
@@ -7417,10 +7418,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -18959,10 +18960,9 @@
       }
     },
     "flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@types/eslint": "^9.6.1",
+    "flatted": "^3.3.3",
     "jest-worker": "^29.7.0",
     "micromatch": "^4.0.8",
     "normalize-path": "^3.0.0",

--- a/src/getESLint.js
+++ b/src/getESLint.js
@@ -6,6 +6,7 @@ const { Worker: JestWorker } = require('jest-worker');
 const { setup, lintFiles } = require('./worker');
 const { getESLintOptions } = require('./options');
 const { jsonStringifyReplacerSortKeys } = require('./utils');
+const { stringify } = require('flatted');
 
 /** @type {{[key: string]: any}} */
 const cache = {};
@@ -115,7 +116,7 @@ async function getESLint(key, { threads, ...options }) {
  * @returns {string}
  */
 function getCacheKey(key, options) {
-  return JSON.stringify({ key, options }, jsonStringifyReplacerSortKeys);
+  return stringify({ key, options }, jsonStringifyReplacerSortKeys);
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,9 +104,13 @@ const jsonStringifyReplacerSortKeys = (_, value) => {
     return sorted;
   };
 
-  return value instanceof Object && !(value instanceof Array)
-    ? Object.keys(value).sort().reduce(insert, {})
-    : value;
+  if (value instanceof Object && !(value instanceof Array)) {
+    let sorted = Object.keys(value).sort().reduce(insert, {});
+    Object.keys(value).forEach((key) => delete value[key]);
+    Object.assign(value, sorted);
+  }
+
+  return value;
 };
 
 module.exports = {

--- a/test/circular-plugin.test.js
+++ b/test/circular-plugin.test.js
@@ -1,0 +1,34 @@
+import pack from './utils/pack';
+
+describe('circular plugin', () => {
+  it('should support plugins with circular configs', async () => {
+    const plugin = {
+      configs: {},
+      rules: {},
+      processors: {},
+    };
+
+    Object.assign(plugin.configs, {
+      recommended: {
+        plugins: {
+          self: plugin,
+        },
+        rules: {},
+      },
+    });
+
+    const loaderOptions = {
+      configType: 'flat',
+      overrideConfig: {
+        plugins: { plugin: plugin },
+      },
+      overrideConfigFile: true,
+    };
+
+    const compiler = pack('good', loaderOptions);
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
+  });
+});

--- a/test/circular-plugin.test.js
+++ b/test/circular-plugin.test.js
@@ -1,34 +1,38 @@
 import pack from './utils/pack';
+import { ESLint } from 'eslint';
 
-describe('circular plugin', () => {
-  it('should support plugins with circular configs', async () => {
-    const plugin = {
-      configs: {},
-      rules: {},
-      processors: {},
-    };
-
-    Object.assign(plugin.configs, {
-      recommended: {
-        plugins: {
-          self: plugin,
-        },
+(ESLint && parseFloat(ESLint.version) < 9 ? describe.skip : describe)(
+  'circular plugin',
+  () => {
+    it('should support plugins with circular configs', async () => {
+      const plugin = {
+        configs: {},
         rules: {},
-      },
+        processors: {},
+      };
+
+      Object.assign(plugin.configs, {
+        recommended: {
+          plugins: {
+            self: plugin,
+          },
+          rules: {},
+        },
+      });
+
+      const loaderOptions = {
+        configType: 'flat',
+        overrideConfig: {
+          plugins: { plugin: plugin },
+        },
+        overrideConfigFile: true,
+      };
+
+      const compiler = pack('good', loaderOptions);
+
+      const stats = await compiler.runAsync();
+      expect(stats.hasWarnings()).toBe(false);
+      expect(stats.hasErrors()).toBe(false);
     });
-
-    const loaderOptions = {
-      configType: 'flat',
-      overrideConfig: {
-        plugins: { plugin: plugin },
-      },
-      overrideConfigFile: true,
-    };
-
-    const compiler = pack('good', loaderOptions);
-
-    const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
-  });
-});
+  },
+);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Previously, attempting to use an overridden config containing a plugin with a circular structure (as is suggested for flat configs) would error, as the caching implementation would attempt to `JSON.stringify` said plugins in order to use them as cache keys.

This PR fixes the issue by using `flatted` to perform the conversion instead, which is capable of handling circular objects.

A test case (verified to error without the fix) is also included.

Fixes: #270.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None.

### Additional Info

The changes to `jsonStringifyReplacerSortKeys` are required as returning new objects from the replacer function causes `flatted` to enter an infinite loop as it attempts to deal with the ever expanding set of references, eventually running out of memory. I address that by overwriting the object in-place; I'd strongly recommend giving those specific changes a good look, as any mistakes could corrupt the options object for all later code. In particular, I'm not 100% sure if `Object.assign` is the best option here, but it could be completely fine.

Test case plugin code is taken almost exactly from https://eslint.org/docs/latest/extend/plugin-migration-flat-config#migrating-configs-for-flat-config; it is probably possible to make it a bit shorter, but I didn't bother to look into it.

`npm run test` was run immediately prior to the final (and only) commit, so any stylistic lints should have been applied, but apologies if I've missed anything.