### PR TITLE
Change `.eslintrc` to `eslint.config.js` since ESLint v9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can pass [ESLint Node.js API options](https://eslint.org/docs/developer-guid
 > [!NOTE]
 >
 > The config option you provide will be passed to the `ESLint` class.
-> This is a different set of options than what you'd specify in `package.json` or `.eslintrc`.
+> This is a different set of options than what you'd specify in `package.json` or `eslint.config.js` (since ESLint v9.0.0, formerly `.eslintrc`).
 > See the [ESlint docs](https://eslint.org/docs/developer-guide/nodejs-api#-new-eslintoptions) for more details.
 
 > [!WARNING]


### PR DESCRIPTION
This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

`.eslintrc` changed to `eslint.config.js` since ESLint v9.0.0

c.f. https://eslint.org/docs/latest/use/configure/migration-guide

### Breaking Changes

### Additional Info
