### PR TITLE
fix(plugin): isolate ESLint instance per webpack config in non-thread…

### DIFF
--- a/src/getESLint.js
+++ b/src/getESLint.js
@@ -3,7 +3,7 @@ const { cpus } = require('os');
 const { Worker: JestWorker } = require('jest-worker');
 
 // @ts-ignore
-const { setup, lintFiles } = require('./worker');
+const { setup } = require('./worker');
 const { getESLintOptions } = require('./options');
 const { jsonStringifyReplacerSortKeys } = require('./utils');
 const { stringify } = require('flatted');
@@ -25,7 +25,7 @@ const cache = {};
  */
 async function loadESLint(options) {
   const { eslintPath } = options;
-  const eslint = await setup({
+  const eslintPack = await setup({
     eslintPath,
     configType: options.configType,
     eslintOptions: getESLintOptions(options),
@@ -33,8 +33,8 @@ async function loadESLint(options) {
 
   return {
     threads: 1,
-    lintFiles,
-    eslint,
+    lintFiles : eslintPack.lintFiles,
+    eslint : eslintPack.eslint,
     // no-op for non-threaded
     cleanup: async () => {},
   };


### PR DESCRIPTION
Hello

Avoid reusing global ESLint instances across multiple webpack configurations. This change corrects issues with incorrect cwd and context resolution caused by shared state between configurations. Note: Threaded mode remains broken due to fundamental architectural flaws and would require a full rewrite to function correctly.

Fixes [#286](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/286)

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**

### Motivation / Use-Case
This fix addresses the use case of multiple webpack configurations where the previous implementation shares the same incorrect eslint instance.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Threaded mode is currently broken and now considered unsupported.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
This PR is not meant to be merged as-is. It serves as a proof of concept or inspiration.
The threaded mode is fundamentally flawed: setup is invoked multiple times for the same worker, and most operations are incorrectly executed on the main thread instead of worker threads.
Fixing this would require a complete architectural rewrite, which I am not undertaking, as I do not use threaded mode myself.
The current implementation leads to redundant and duplicated work, making it non-viable in practice.


Have a nice day 